### PR TITLE
fix(build): renamed option key to _option

### DIFF
--- a/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-dev-server-plugin.spec.ts
+++ b/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-dev-server-plugin.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NgRspackModuleFederationDevServerPlugin } from './ng-rspack-module-federation-dev-server-plugin';
+
+// Mock dependencies
+vi.mock('nx/src/project-graph/project-graph', () => ({
+  readCachedProjectGraph: vi.fn(() => ({
+    nodes: {
+      testApp: {
+        data: {
+          targets: {
+            build: {
+              options: {
+                outputPath: 'dist/apps/test-app',
+              },
+            },
+            serve: {
+              options: {
+                port: 4200,
+              },
+            },
+          },
+        },
+      },
+    },
+  })),
+  readProjectsConfigurationFromProjectGraph: vi.fn(() => ({
+    projects: {
+      testApp: {
+        name: 'testApp',
+      },
+    },
+  })),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(),
+  cpSync: vi.fn(),
+  createWriteStream: vi.fn(),
+}));
+
+describe('NgRspackModuleFederationDevServerPlugin', () => {
+  it('should initialize with provided options', () => {
+    const options = {
+      moduleFederationConfig: {
+        name: 'testApp',
+        remotes: [],
+      },
+      devRemotes: ['remote1'],
+      skipRemotes: ['skip1'],
+      host: 'localhost',
+      staticRemotesPort: 3000,
+      pathToManifestFile: 'path/to/manifest.json',
+      ssl: true,
+      sslCert: 'path/to/cert.pem',
+      sslKey: 'path/to/key.pem',
+      parallel: 3,
+    };
+
+    const plugin = new NgRspackModuleFederationDevServerPlugin(options);
+
+    // Assert
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options).toBeDefined();
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options).toEqual(options);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.moduleFederationConfig.name).toBe('testApp');
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.devRemotes).toEqual(['remote1']);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.skipRemotes).toEqual(['skip1']);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.host).toBe('localhost');
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.staticRemotesPort).toBe(3000);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.pathToManifestFile).toBe('path/to/manifest.json');
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.ssl).toBe(true);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.sslCert).toBe('path/to/cert.pem');
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.sslKey).toBe('path/to/key.pem');
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.parallel).toBe(3);
+  });
+});

--- a/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-dev-server-plugin.ts
+++ b/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-dev-server-plugin.ts
@@ -28,7 +28,7 @@ export class NgRspackModuleFederationDevServerPlugin
   private nxBin: string;
 
   constructor(
-    private options: {
+    private _options: {
       moduleFederationConfig: ModuleFederationConfig;
       devRemotes: string[];
       skipRemotes: string[];
@@ -60,10 +60,10 @@ export class NgRspackModuleFederationDevServerPlugin
         this.startRemoteProxies(
           staticRemotesConfig,
           mappedLocationOfRemotes!,
-          this.options.ssl
+          this._options.ssl
             ? {
-                pathToCert: this.options.sslCert!,
-                pathToKey: this.options.sslKey!,
+                pathToCert: this._options.sslCert!,
+                pathToKey: this._options.sslKey!,
               }
             : undefined
         );
@@ -76,50 +76,51 @@ export class NgRspackModuleFederationDevServerPlugin
     const projectGraph = readCachedProjectGraph();
     const { projects: workspaceProjects } =
       readProjectsConfigurationFromProjectGraph(projectGraph);
-    const project = workspaceProjects[this.options.moduleFederationConfig.name];
-    if (!this.options.pathToManifestFile) {
-      this.options.pathToManifestFile = getDynamicMfManifestFile(
+    const project =
+      workspaceProjects[this._options.moduleFederationConfig.name];
+    if (!this._options.pathToManifestFile) {
+      this._options.pathToManifestFile = getDynamicMfManifestFile(
         project,
         workspaceRoot
       );
     } else {
       const userPathToManifestFile = join(
         workspaceRoot,
-        this.options.pathToManifestFile
+        this._options.pathToManifestFile
       );
       if (!existsSync(userPathToManifestFile)) {
         throw new Error(
           `The provided Module Federation manifest file path does not exist. Please check the file exists at "${userPathToManifestFile}".`
         );
-      } else if (extname(this.options.pathToManifestFile) !== '.json') {
+      } else if (extname(this._options.pathToManifestFile) !== '.json') {
         throw new Error(
           `The Module Federation manifest file must be a JSON. Please ensure the file at ${userPathToManifestFile} is a JSON.`
         );
       }
 
-      this.options.pathToManifestFile = userPathToManifestFile;
+      this._options.pathToManifestFile = userPathToManifestFile;
     }
 
     validateDevRemotes(
-      { devRemotes: this.options.devRemotes },
+      { devRemotes: this._options.devRemotes },
       workspaceProjects
     );
 
-    const remoteNames = this.options.devRemotes.map((r) => r);
+    const remoteNames = this._options.devRemotes.map((r) => r);
 
     const remotes = getRemotes(
       remoteNames,
-      this.options.skipRemotes,
-      this.options.moduleFederationConfig,
+      this._options.skipRemotes,
+      this._options.moduleFederationConfig,
       {
         projectName: project.name ?? '',
         projectGraph,
         root: workspaceRoot,
       },
-      this.options.pathToManifestFile
+      this._options.pathToManifestFile
     );
 
-    this.options.staticRemotesPort ??= remotes.staticRemotePort;
+    this._options.staticRemotesPort ??= remotes.staticRemotePort;
 
     // Set NX_MF_DEV_REMOTES for the Nx Runtime Library Control Plugin
     process.env['NX_MF_DEV_REMOTES'] = JSON.stringify([
@@ -162,9 +163,9 @@ export class NgRspackModuleFederationDevServerPlugin
     }
     const mappedLocationOfRemotes: Record<string, string> = {};
     for (const app of staticRemotesConfig.remotes) {
-      mappedLocationOfRemotes[app] = `http${this.options.ssl ? 's' : ''}://${
-        this.options.host
-      }:${this.options.staticRemotesPort}/${
+      mappedLocationOfRemotes[app] = `http${this._options.ssl ? 's' : ''}://${
+        this._options.host
+      }:${this._options.staticRemotesPort}/${
         staticRemotesConfig.config?.[app].urlSegment
       }`;
     }
@@ -179,8 +180,8 @@ export class NgRspackModuleFederationDevServerPlugin
           'run-many',
           `--target=build`,
           `--projects=${staticRemotesConfig.remotes.join(',')}`,
-          ...(this.options.parallel
-            ? [`--parallel=${this.options.parallel}`]
+          ...(this._options.parallel
+            ? [`--parallel=${this._options.parallel}`]
             : []),
         ],
         {
@@ -298,7 +299,7 @@ export class NgRspackModuleFederationDevServerPlugin
       pathToHttpServer,
       [
         commonOutputDirectory!,
-        `-p=${this.options.staticRemotesPort}`,
+        `-p=${this._options.staticRemotesPort}`,
         `-a=localhost`,
         `--cors`,
       ],

--- a/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-plugin.spec.ts
+++ b/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-plugin.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NgRspackModuleFederationPlugin } from './ng-rspack-module-federation-plugin';
+
+// Mock dependencies
+vi.mock('nx/src/project-graph/project-graph', () => ({
+  readCachedProjectGraph: vi.fn(() => ({
+    nodes: {
+      testApp: {
+        data: {
+          targets: {
+            build: {
+              options: {
+                outputPath: 'dist/apps/test-app',
+              },
+            },
+            serve: {
+              options: {
+                port: 4200,
+              },
+            },
+          },
+        },
+      },
+    },
+  })),
+  readProjectsConfigurationFromProjectGraph: vi.fn(() => ({
+    projects: {
+      testApp: {
+        name: 'testApp',
+      },
+    },
+  })),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(),
+  cpSync: vi.fn(),
+  createWriteStream: vi.fn(),
+}));
+
+describe('NgRspackModuleFederationDevServerPlugin', () => {
+  it('should initialize with provided options', () => {
+    const options = {
+      name: 'testApp',
+      remotes: [],
+    };
+    const plugin = new NgRspackModuleFederationPlugin(options);
+
+    // Assert
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options).toBeDefined();
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options).toEqual(options);
+    // @ts-expect-error: Accessing private property for testing
+    expect(plugin._options.name).toBe('testApp');
+  });
+});

--- a/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-plugin.ts
+++ b/packages/build/src/lib/plugins/module-federation/ng-rspack-module-federation-plugin.ts
@@ -15,7 +15,7 @@ export class NgRspackModuleFederationPlugin implements RspackPluginInstance {
   private mappedRemotes: MappedRemotes | undefined;
 
   constructor(
-    private options: ModuleFederationConfig,
+    private _options: ModuleFederationConfig,
     private configOverride?: NgRspackModuleFederationConfigOverride,
     private remoteOptions?: { devRemotes?: string[]; skipRemotes?: string[] }
   ) {}
@@ -33,15 +33,15 @@ export class NgRspackModuleFederationPlugin implements RspackPluginInstance {
     const isDevServer =
       !!process.env['WEBPACK_SERVE'] && !process.env['NG_RSPACK_INITIAL_HOST'];
 
-    const config = getModuleFederationConfig(this.options);
+    const config = getModuleFederationConfig(this._options);
     this.sharedLibraries = config.sharedLibraries;
     this.sharedDependencies = config.sharedDependencies;
     this.mappedRemotes = config.mappedRemotes;
 
     new (require('@module-federation/enhanced/rspack').ModuleFederationPlugin)({
-      name: this.options.name.replace(/-/g, '_'),
+      name: this._options.name.replace(/-/g, '_'),
       filename: 'remoteEntry.js',
-      exposes: this.options.exposes,
+      exposes: this._options.exposes,
       remotes: this.mappedRemotes,
       shared: {
         ...(this.sharedDependencies ?? {}),
@@ -60,7 +60,7 @@ export class NgRspackModuleFederationPlugin implements RspackPluginInstance {
     if (isDevServer) {
       process.env['NG_RSPACK_INITIAL_HOST'] = 'set';
       new NgRspackModuleFederationDevServerPlugin({
-        moduleFederationConfig: this.options,
+        moduleFederationConfig: this._options,
         host: 'localhost',
         devRemotes: this.remoteOptions
           ? this.remoteOptions.devRemotes ?? []


### PR DESCRIPTION
## Description
This PR updates the NgRspackModuleFederationPlugin to standardize the attribute name from options to _options, aligning it with the naming conventions used in other Module Federation plugins. This change resolves the inconsistency and improves compatibility across plugins.

## Changes
Renamed options to _options throughout the plugin configuration.
Updated all references to use _options instead of options.
This update should improve interoperability for users who rely on a consistent API structure across Module Federation plugins.

Closes #25 