### PR TITLE
chore(repo): use local plugin for e2e

### DIFF
--- a/apps/rsbuild/csr/css-e2e/tsconfig.json
+++ b/apps/rsbuild/csr/css-e2e/tsconfig.json
@@ -21,5 +21,10 @@
     "src/**/*.test.ts",
     "src/**/*.test.js",
     "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    }
   ]
 }

--- a/apps/rsbuild/csr/css/tsconfig.app.json
+++ b/apps/rsbuild/csr/css/tsconfig.app.json
@@ -20,5 +20,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular/tsconfig.lib.json"
+    }
   ]
 }

--- a/apps/rsbuild/csr/css/tsconfig.json
+++ b/apps/rsbuild/csr/css/tsconfig.json
@@ -13,6 +13,9 @@
   "include": [],
   "references": [
     {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    },
+    {
       "path": "./tsconfig.editor.json"
     },
     {

--- a/apps/rsbuild/csr/scss-e2e/tsconfig.json
+++ b/apps/rsbuild/csr/scss-e2e/tsconfig.json
@@ -21,5 +21,10 @@
     "src/**/*.test.ts",
     "src/**/*.test.js",
     "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    }
   ]
 }

--- a/apps/rsbuild/csr/scss/tsconfig.app.json
+++ b/apps/rsbuild/csr/scss/tsconfig.app.json
@@ -20,5 +20,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular/tsconfig.lib.json"
+    }
   ]
 }

--- a/apps/rsbuild/csr/scss/tsconfig.json
+++ b/apps/rsbuild/csr/scss/tsconfig.json
@@ -13,6 +13,9 @@
   "include": [],
   "references": [
     {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    },
+    {
       "path": "./tsconfig.editor.json"
     },
     {

--- a/apps/rsbuild/ssr/css-e2e/tsconfig.json
+++ b/apps/rsbuild/ssr/css-e2e/tsconfig.json
@@ -21,5 +21,10 @@
     "src/**/*.test.ts",
     "src/**/*.test.js",
     "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    }
   ]
 }

--- a/apps/rsbuild/ssr/css/tsconfig.app.json
+++ b/apps/rsbuild/ssr/css/tsconfig.app.json
@@ -20,5 +20,10 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx"
+  ],
+  "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular/tsconfig.lib.json"
+    }
   ]
 }

--- a/apps/rsbuild/ssr/css/tsconfig.json
+++ b/apps/rsbuild/ssr/css/tsconfig.json
@@ -7,11 +7,19 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@ng-rsbuild/plugin-angular/ssr": [
+        "../../../../packages/rsbuild-plugin-angular/dist/lib/ssr/server"
+      ]
+    }
   },
   "files": [],
   "include": [],
   "references": [
+    {
+      "path": "../../../../packages/rsbuild-plugin-angular"
+    },
     {
       "path": "./tsconfig.editor.json"
     },

--- a/nx.json
+++ b/nx.json
@@ -46,6 +46,14 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
+    "e2e": {
+      "parallelism": false,
+      "dependsOn": ["^build"]
+    },
+    "e2e-ci": {
+      "parallelism": false,
+      "dependsOn": ["^build"]
+    },
     "e2e-ci--**/*": {
       "parallelism": false,
       "dependsOn": ["^build"]

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@eslint/js": "^9.8.0",
     "@module-federation/enhanced": "0.8.5",
     "@module-federation/sdk": "0.8.5",
-    "@ng-rsbuild/plugin-angular": "19.0.0-alpha.14",
     "@nx/angular": "20.3.0",
     "@nx/eslint": "20.3.0",
     "@nx/eslint-plugin": "20.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       '@module-federation/sdk':
         specifier: 0.8.5
         version: 0.8.5
-      '@ng-rsbuild/plugin-angular':
-        specifier: 19.0.0-alpha.14
-        version: 19.0.0-alpha.14(6lif27fx3r3immrdmltl76ku4y)
       '@nx/angular':
         specifier: 20.3.0
         version: 20.3.0(@angular-devkit/build-angular@19.0.5(irp3dpp7ixbs57rqzv34p6o4ea))(@angular-devkit/core@19.0.5)(@angular-devkit/schematics@19.0.5)(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.15))(@schematics/angular@19.0.5)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(eslint@9.17.0(jiti@2.4.2))(nx@20.3.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(sass-embedded@1.83.0)(typescript@5.6.3)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))
@@ -332,8 +329,8 @@ importers:
   packages/nx-plugin:
     dependencies:
       '@ng-rspack/build':
-        specifier: 0.0.35
-        version: 0.0.35(x34coi4evj6qqfay62a7xd5hru)
+        specifier: 19.0.0-alpha.14
+        version: 19.0.0-alpha.14(x34coi4evj6qqfay62a7xd5hru)
       '@nx/angular':
         specifier: 20.2.2
         version: 20.2.2(@angular-devkit/build-angular@19.0.6(bm243jpuv433i43deyd6jvtlbu))(@angular-devkit/core@19.0.6(chokidar@4.0.3))(@angular-devkit/schematics@19.0.6(chokidar@4.0.3))(@babel/traverse@7.26.4)(@rspack/core@1.1.8(@swc/helpers@0.5.15))(@schematics/angular@19.0.6(chokidar@4.0.3))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@18.16.9)(@zkochan/js-yaml@0.0.7)(eslint@9.17.0(jiti@2.4.2))(nx@20.3.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(sass-embedded@1.83.0)(typescript@5.6.3)(verdaccio@5.33.0(encoding@0.1.13)(typanion@3.14.0))
@@ -2398,19 +2395,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@ng-rsbuild/plugin-angular@19.0.0-alpha.14':
-    resolution: {integrity: sha512-gIRvit3VHSve/x4DidPjW1bKbcVGad/hTbny0P+nLlMW3ZXiUnFppy1k0VG/klD+mlZIt5ZTh9+GJ3hrdh101Q==}
-    peerDependencies:
-      '@angular-devkit/build-angular': '>=19.0.0 <20.0.0'
-      '@angular/build': '>=18.0.0 <20.0.0'
-      '@angular/common': '>=19.0.0 <20.0.0'
-      '@angular/compiler-cli': '>=19.0.0 <20.0.0'
-      '@angular/ssr': '>=19.0.0 <20.0.0'
-      '@rsbuild/core': '>=1.0.5 <2.0.0'
-      '@swc/core': '>=1.5.0 <1.11.0'
-
-  '@ng-rspack/build@0.0.35':
-    resolution: {integrity: sha512-azDXv1zuv1xvWk1PScd4IwlZkTwMobpf7JCdzC49JU0yJbwVfodPCZvt668HuV9VxPLrOfvNcRLXEnN0Usr68A==}
+  '@ng-rspack/build@19.0.0-alpha.14':
+    resolution: {integrity: sha512-DcsB46Skmyi2r9AlPoFe5d7q7c9CQmD5WEyEmvk9ImTuitbE9n4rXEewOob65/FDcO+mmBek3C7cvcsifMJhuA==}
     peerDependencies:
       '@angular-devkit/build-angular': '>=19.0.0 <20.0.0'
       '@angular/build': '>=18.0.0 <20.0.0'
@@ -11778,24 +11764,7 @@ snapshots:
       '@emnapi/runtime': 1.3.1
       '@tybys/wasm-util': 0.9.0
 
-  '@ng-rsbuild/plugin-angular@19.0.0-alpha.14(6lif27fx3r3immrdmltl76ku4y)':
-    dependencies:
-      '@angular-devkit/build-angular': 19.0.5(irp3dpp7ixbs57rqzv34p6o4ea)
-      '@angular/build': 19.0.5(@angular/compiler-cli@19.0.5(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.0.5(@angular/animations@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.5(@angular/animations@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.0.5(whst2uom2sykn2ay52lywk7vqm))(@types/node@18.16.9)(less@4.1.3)(postcss@8.4.49)(sass-embedded@1.83.0)(stylus@0.64.0)(terser@5.36.0)(typescript@5.6.3)
-      '@angular/common': 19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
-      '@angular/compiler-cli': 19.0.5(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
-      '@angular/ssr': 19.0.5(whst2uom2sykn2ay52lywk7vqm)
-      '@rsbuild/core': 1.1.13
-      '@swc/core': 1.5.29(@swc/helpers@0.5.15)
-      express: 4.21.1
-      sass-embedded: 1.83.0
-      ts-morph: 24.0.0
-      tslib: 2.8.1
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ng-rspack/build@0.0.35(x34coi4evj6qqfay62a7xd5hru)':
+  '@ng-rspack/build@19.0.0-alpha.14(x34coi4evj6qqfay62a7xd5hru)':
     dependencies:
       '@angular-devkit/build-angular': 19.0.6(bm243jpuv433i43deyd6jvtlbu)
       '@angular/build': 19.0.6(@angular/compiler-cli@19.0.5(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/platform-server@19.0.5(@angular/animations@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.5(@angular/animations@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.5(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.5(rxjs@7.8.1)(zone.js@0.15.0))))(@angular/ssr@19.0.6(whst2uom2sykn2ay52lywk7vqm))(@types/node@18.16.9)(chokidar@4.0.3)(less@4.1.3)(postcss@8.4.49)(sass-embedded@1.83.0)(stylus@0.64.0)(terser@5.36.0)(typescript@5.6.3)


### PR DESCRIPTION
This pull request updates the e2e configuration to test the local package `@ng-rsbuild/plugin-angular` instead of the published one. This should help catching bugs before publishing.