### PR TITLE
feat(rsbuild-plugin-angular): add withConfigurations and fileReplacement support #43

### DIFF
--- a/apps/docs/rsbuild.config.ts
+++ b/apps/docs/rsbuild.config.ts
@@ -1,13 +1,31 @@
-import { createConfig, pluginAngular } from '@ng-rsbuild/plugin-angular';
+import { withConfigurations } from '@ng-rsbuild/plugin-angular';
 import { pluginSass } from '@rsbuild/plugin-sass';
 
-const opts = {
+const options = {
   browser: './src/main.ts',
   server: './src/main.server.ts',
   ssrEntry: './src/server.ts',
   inlineStylesExtension: 'scss' as any,
   styles: ['./src/styles.scss', './src/hljs.theme.scss'],
 };
-export default createConfig(opts, {
-  plugins: [pluginSass()],
-});
+
+export default withConfigurations(
+  {
+    options,
+    rsbuildConfigOverrides: {
+      plugins: [pluginSass()],
+    },
+  },
+  {
+    production: {
+      options: {
+        fileReplacements: [
+          {
+            replace: './src/environments/environment.ts',
+            with: './src/environments/environment.prod.ts',
+          },
+        ],
+      },
+    },
+  }
+);

--- a/apps/docs/src/app/app.routes.ts
+++ b/apps/docs/src/app/app.routes.ts
@@ -32,6 +32,23 @@ export const appRoutes: Route[] = [
     ],
   },
   {
+    path: 'guide',
+    children: [
+      {
+        path: 'migration',
+        children: [
+          {
+            path: 'configurations',
+            loadComponent: () =>
+              import(
+                '../pages/guide/migration/configurations/configurations.component'
+              ).then((m) => m.ConfigurationsComponent),
+          },
+        ],
+      },
+    ],
+  },
+  {
     path: 'api',
     component: ApiComponent,
     children: [

--- a/apps/docs/src/environments/environment.prod.ts
+++ b/apps/docs/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  name: 'production',
+};

--- a/apps/docs/src/environments/environment.ts
+++ b/apps/docs/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  name: 'development',
+};

--- a/apps/docs/src/pages/getting-started/introduction/introduction.component.ts
+++ b/apps/docs/src/pages/getting-started/introduction/introduction.component.ts
@@ -10,8 +10,6 @@ import { MatIconModule } from '@angular/material/icon';
       :host {
         max-width: 90vw;
         margin: 0 auto;
-        font-size: 1.15rem;
-        line-height: 2rem;
         @media (min-width: 960px) {
           max-width: 70vw;
         }

--- a/apps/docs/src/pages/guide/migration/configurations/configurations.component.html
+++ b/apps/docs/src/pages/guide/migration/configurations/configurations.component.html
@@ -1,0 +1,87 @@
+<h1>Handling Configurations</h1>
+
+<p>
+  Configurations are handled slightly differently compared to the Angular
+  CLI. Rsbuild and Rspack use <code class="inline-code">mode</code> instead
+  of <code class="inline-code">configurations</code> to handle different
+  environments by default. This means that a different solution is needed to
+  handle different build configurations you may have to match the behavior
+  of Angular's configuration handling.
+</p>
+
+<p>
+  <code class="inline-code">&#64;ng-rsbuild/plugin-angular</code> provides a
+  <a routerLink="/rsbuild/api/with-configurations"
+  ><code class="inline-code">withConfigurations</code></a
+  >
+  function to help you handle this. It uses the <code class="inline-code">NGRS_CONFIG</code> environment variable to determine which configuration to use.
+  The default configuration is <code class="inline-code">production</code>.
+</p>
+
+<app-callout type="info" title="Roll your own">
+  <p>
+    You can handle configurations by yourself if you prefer, all you need
+    is some manner of detecting the environment and then merging the
+    options passed to <code class="inline-code">createConfig</code>.
+  </p>
+</app-callout>
+
+<h3>Using <code class="inline-code">withConfigurations</code></h3>
+
+<p>
+  The <code class="inline-code">withConfigurations</code> function takes two
+  arguments, the first is the default options, and the second is an object
+  of configurations. The configurations object is keyed by the name of the
+  configuration, and the value is an object with the options and
+  <code class="inline-code">rsbuildConfigOverrides</code> to be used for
+  that configuration.
+</p>
+
+<app-code-block language="typescript" fileName="rsbuild.config.ts">
+import &#123; withConfigurations &#125; from '&#64;ng-rsbuild/plugin-angular';
+export default withConfigurations(&#123;
+  options: &#123;
+    browser: './src/main.ts',
+    server: './src/main.server.ts',
+    ssrEntry: './src/server.ts',
+  &#125;,
+  rsbuildConfigOverrides: &#123;
+    plugins: [pluginSass()],
+  &#125;,
+&#125;, &#123;
+  production: &#123;
+    options: &#123;
+      fileReplacements: [
+        &#123;
+          replace: './src/environments/environment.ts',
+          with: './src/environments/environment.prod.ts',
+        &#125;,
+      ],
+    &#125;,
+  &#125;,
+&#125;);
+</app-code-block>
+
+<p>
+  The above example shows how to handle the
+  <code class="inline-code">production</code> configuration. The
+  <code class="inline-code">options</code> are the same as the default
+  options, and the
+  <code class="inline-code">rsbuildConfigOverrides</code> are the same as
+  the default <code class="inline-code">rsbuildConfigOverrides</code> but
+  with the <code class="inline-code">fileReplacements</code> property added.
+</p>
+
+<p>
+  The <code class="inline-code">NGRS_CONFIG</code> environment variable is
+  used to determine which configuration to use. If the environment variable
+  is not set, the <code class="inline-code">production</code> configuration
+  is used by default. <br />
+  If a production configuration is not provided, the default configuration is used.
+</p>
+
+<p>To run the build with the <code class="inline-code">production</code> configuration:</p>
+<app-code-block language="shell">
+NGRS_CONFIG=production npx rsbuild build
+</app-code-block>
+

--- a/apps/docs/src/pages/guide/migration/configurations/configurations.component.ts
+++ b/apps/docs/src/pages/guide/migration/configurations/configurations.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatIcon } from '@angular/material/icon';
+import { CodeBlockComponent } from '../../../../ui/code-block/code-block.component';
+import { CalloutComponent } from '../../../../ui/callout/callout.component';
+
+@Component({
+  preserveWhitespaces: true,
+  selector: 'app-configurations',
+  templateUrl: './configurations.component.html',
+  styles: [
+    `
+      :host {
+        margin: 0 auto;
+        max-width: 85vw;
+        @media (min-width: 960px) {
+          max-width: 70vw;
+        }
+      }
+    `,
+  ],
+  imports: [RouterLink, MatIcon, CodeBlockComponent, CalloutComponent],
+})
+export class ConfigurationsComponent {}

--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -2,6 +2,47 @@
 @use 'sass:color';
 
 /* You can add global styles to this file, and also import other style files */
+
+$mat-sys-info-container: #e8f4f8;
+$mat-sys-info: #006eb3;
+$mat-sys-warning-container: #fff3cd;
+$mat-sys-warning: #ff9800;
+$mat-sys-error-container: #ffebee;
+$mat-sys-error: #d32f2f;
+
+$mat-sys-info-container__dark: #2f516c;
+$mat-sys-info__dark: #005ab3;
+$mat-sys-warning-container__dark: color.invert(
+  $mat-sys-warning-container,
+  100%,
+  $space: rgb
+);
+$mat-sys-warning__dark: color.invert($mat-sys-warning, 100%, $space: rgb);
+$mat-sys-error-container__dark: color.invert(
+  $mat-sys-error-container,
+  100%,
+  $space: rgb
+);
+$mat-sys-error__dark: color.invert($mat-sys-error, 100%, $space: rgb);
+
+:root {
+  --mat-sys-info-container: #{$mat-sys-info-container};
+  --mat-sys-info: #{$mat-sys-info};
+  --mat-sys-warning-container: #{$mat-sys-warning-container};
+  --mat-sys-warning: #{$mat-sys-warning};
+  --mat-sys-error-container: #{$mat-sys-error-container};
+  --mat-sys-error: #{$mat-sys-error};
+
+  @media (prefers-color-scheme: dark) {
+    --mat-sys-info-container: #{$mat-sys-info-container__dark};
+    --mat-sys-info: #{$mat-sys-info__dark};
+    --mat-sys-warning-container: #{$mat-sys-warning-container__dark};
+    --mat-sys-warning: #{$mat-sys-warning__dark};
+    --mat-sys-error-container: #{$mat-sys-error-container__dark};
+    --mat-sys-error: #{$mat-sys-error__dark};
+  }
+}
+
 html {
   color-scheme: light dark;
   @include mat.theme(
@@ -25,6 +66,7 @@ body {
 body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
+  line-height: 1.5rem;
 }
 
 code.inline-code {

--- a/apps/docs/src/ui/callout/callout.component.ts
+++ b/apps/docs/src/ui/callout/callout.component.ts
@@ -1,0 +1,81 @@
+import { Component, computed, input } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-callout',
+  template: `
+    <div
+      class="callout"
+      [class.info]="type() === 'info'"
+      [class.warning]="type() === 'warning'"
+      [class.error]="type() === 'error'"
+    >
+      <div class="callout-header">
+        <mat-icon>{{ icon() }}</mat-icon>
+        <h3>{{ title() }}</h3>
+      </div>
+      <div class="callout-content">
+        <ng-content></ng-content>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        padding: 0.75rem 0;
+        font-size: 0.85rem;
+      }
+
+      .callout {
+        border: 1px solid var(--mat-sys-surface-variant);
+        border-radius: 0.5rem;
+        background-color: var(--mat-sys-surface-container);
+        padding: 0.5rem;
+
+        &.info {
+          border-color: var(--mat-sys-info);
+          background-color: var(--mat-sys-info-container);
+        }
+
+        &.error {
+          border-color: var(--mat-sys-error);
+          background-color: var(--mat-sys-error-container);
+        }
+
+        &.warning {
+          border-color: var(--mat-sys-warning);
+          background-color: var(--mat-sys-warning-container);
+        }
+      }
+
+      .callout-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        h3 {
+          margin: 0;
+          font-size: 0.95rem;
+        }
+      }
+
+      .callout-content {
+        padding-top: 0.25rem;
+      }
+    `,
+  ],
+  imports: [MatIcon],
+})
+export class CalloutComponent {
+  type = input<'info' | 'warning' | 'error'>('info');
+  icon = computed(() => {
+    switch (this.type()) {
+      case 'info':
+        return 'info';
+      case 'warning':
+        return 'warning';
+      case 'error':
+        return 'error';
+    }
+  });
+  title = input<string>('Info');
+}

--- a/apps/docs/src/ui/drawer.component.ts
+++ b/apps/docs/src/ui/drawer.component.ts
@@ -31,6 +31,7 @@ interface DrawerLink {
         mat-list-item
         [routerLink]="childLink.href"
         [activated]="childLink.href === activeRoute"
+        class="subheader-link-item"
         >{{ childLink.label }}</a
       >
       } } @else {
@@ -50,14 +51,17 @@ interface DrawerLink {
         font-size: 1.15rem;
         font-weight: 500;
         border-top: 1px solid var(--mat-sys-surface-variant);
-        border-bottom: 1px solid var(--mat-sys-surface-variant);
       }
 
       .subheader {
-        font-size: 0.85rem;
+        font-size: 1rem;
         font-weight: 500;
         border-top: 1px solid var(--mat-sys-surface-variant);
         border-bottom: 1px solid var(--mat-sys-surface-variant);
+      }
+
+      .subheader-link-item {
+        --mdc-list-list-item-label-text-size: 0.85rem;
       }
     `,
   ],
@@ -92,6 +96,25 @@ export class DrawerComponent {
           isActive: false,
           href: '/getting-started/quick-start',
           label: 'Quick Start',
+        },
+      ],
+    },
+    {
+      isActive: false,
+      href: '/guide',
+      label: 'Guide',
+      children: [],
+    },
+    {
+      isActive: false,
+      href: '/guide/migration',
+      label: 'Migration',
+      subheader: true,
+      children: [
+        {
+          isActive: false,
+          href: '/guide/migration/configurations',
+          label: 'Configurations',
         },
       ],
     },

--- a/apps/docs/src/ui/footer.component.ts
+++ b/apps/docs/src/ui/footer.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
+import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-footer',
@@ -11,6 +12,11 @@ import { Component } from '@angular/core';
       />
       <p>Angular Rspack and Rsbuild Tools. Licensed under MIT.</p>
       <a href="https://github.com/Coly010/ng-rspack-build">GitHub</a>
+      <div class="rsbuild-callout">
+        <p>
+          Built for {{ env() }} by <a href="https://rsbuild.dev">Rsbuild</a>
+        </p>
+      </div>
     </footer>
   `,
   styles: [
@@ -23,8 +29,15 @@ import { Component } from '@angular/core';
         img {
           opacity: 0.5;
         }
+
+        .rsbuild-callout {
+          margin-top: 1rem;
+          border-top: 1px solid var(--mat-sys-surface-variant);
+        }
       }
     `,
   ],
 })
-export class FooterComponent {}
+export class FooterComponent {
+  env = computed(() => environment.name);
+}

--- a/packages/rsbuild-plugin-angular/src/index.ts
+++ b/packages/rsbuild-plugin-angular/src/index.ts
@@ -1,7 +1,7 @@
 import { pluginAngular } from './lib/plugin/plugin-angular';
 import { PluginAngularOptions } from './lib/models/plugin-options';
-import { createConfig } from './lib/config/create-config';
+import { createConfig, withConfigurations } from './lib/config/create-config';
 
-export { pluginAngular, createConfig };
+export { pluginAngular, createConfig, withConfigurations };
 export type { PluginAngularOptions };
 export default pluginAngular;

--- a/packages/rsbuild-plugin-angular/src/lib/models/normalize-options.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/models/normalize-options.ts
@@ -1,5 +1,5 @@
 import { PluginAngularOptions } from './plugin-options';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 
 export function normalizeOptions(
@@ -15,6 +15,7 @@ export function normalizeOptions(
     assets: options.assets ?? ['./public'],
     styles: options.styles ?? ['./src/styles.css'],
     scripts: options.scripts ?? [],
+    fileReplacements: options.fileReplacements ?? [],
     jit: options.jit ?? false,
     inlineStylesExtension: options.inlineStylesExtension ?? 'css',
     tsconfigPath:
@@ -24,6 +25,13 @@ export function normalizeOptions(
       options.useHoistedJavascriptProcessing ?? true,
     useParallelCompilation: options.useParallelCompilation ?? true,
   };
+
+  normalizedOptions.fileReplacements = options.fileReplacements
+    ? options.fileReplacements.map((fileReplacement) => ({
+        replace: resolve(normalizedOptions.root, fileReplacement.replace),
+        with: resolve(normalizedOptions.root, fileReplacement.with),
+      }))
+    : [];
   if (
     options.server &&
     options.ssrEntry &&

--- a/packages/rsbuild-plugin-angular/src/lib/models/plugin-options.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/models/plugin-options.ts
@@ -1,3 +1,8 @@
+export interface FileReplacement {
+  replace: string;
+  with: string;
+}
+
 export interface PluginAngularOptions {
   root: string;
   index: string;
@@ -8,6 +13,7 @@ export interface PluginAngularOptions {
   assets: string[];
   styles: string[];
   scripts: string[];
+  fileReplacements: FileReplacement[];
   jit: boolean;
   inlineStylesExtension: 'css' | 'scss' | 'sass' | 'less';
   tsconfigPath: string;

--- a/packages/rsbuild-plugin-angular/src/lib/plugin/compilation/setup-compilation.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/plugin/compilation/setup-compilation.ts
@@ -71,11 +71,18 @@ export async function setupCompilationWithParallelCompilation(
 ) {
   const { rootNames, compilerOptions } = setupCompilation(config, options);
   const parallelCompilation = new ParallelCompilation(options.jit ?? false);
+  const fileReplacements: Record<string, string> =
+    options.fileReplacements.reduce((r, f) => {
+      r[f.replace] = f.with;
+      return r;
+    }, {});
 
   try {
     await parallelCompilation.initialize(
       config.source?.tsconfigPath ?? options.tsconfigPath,
       {
+        ...compilerOptions,
+        fileReplacements,
         modifiedFiles: new Set(rootNames),
         async transformStylesheet(data) {
           const result = sassCompileString(data);

--- a/packages/rsbuild-plugin-angular/src/lib/plugin/plugin-angular.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/plugin/plugin-angular.ts
@@ -84,6 +84,12 @@ export const pluginAngular = (
           };
         });
       }
+
+      config.resolve ??= {};
+      config.resolve.alias ??= {};
+      for (const fileReplacement of options.fileReplacements ?? []) {
+        config.resolve.alias[fileReplacement.replace] = fileReplacement.with;
+      }
     });
 
     api.onDevCompileDone(({ environments }) => {


### PR DESCRIPTION
## Current Behaviour
There is currently no support for `fileReplacements` as supported by the Angular CLI.
Additionally, there is no provided way to handle environments.
It could be hand-rolled, but it is helpful to have a builtin method for handling this.

## Changed Behaviour 
Add File Replacement Support
Add `withConfigurations` as a method for creating configuration that will allow for providing configurations with differing options and a standard method for merging the options and rsbuild config overrides.

Closes #43
