### PR TITLE
fix(docs): plugin package name in get started guide

### DIFF
--- a/apps/docs/src/pages/getting-started/quick-start/quick-start.component.html
+++ b/apps/docs/src/pages/getting-started/quick-start/quick-start.component.html
@@ -47,7 +47,7 @@ cd myorg
 
 npx nx add &#64;nx/rsbuild
 
-npm install &#64;ng-rsbuild/nx-plugin
+npm install &#64;ng-rsbuild/plugin-nx
 
 npx nx g &#64;ng-rsbuild/nx:application myapp
     </app-code-block>


### PR DESCRIPTION
The PR fixes the npm package path for the rsbuild nx plugin in the get started guide, which should have been:

```
npm install @ng-rsbuild/plugin-nx
```