### PR TITLE
feat(rsbuild-plugin-angular): remove non parallel build

### DIFF
--- a/packages/rsbuild-plugin-angular/src/lib/models/normalize-options.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/models/normalize-options.ts
@@ -48,8 +48,6 @@ export const DEFAULT_PLUGIN_ANGULAR_OPTIONS: PluginAngularOptions = {
   jit: false,
   inlineStylesExtension: 'css',
   tsconfigPath: join(process.cwd(), 'tsconfig.app.json'),
-  useHoistedJavascriptProcessing: true,
-  useParallelCompilation: true,
 };
 
 export function normalizeOptions(

--- a/packages/rsbuild-plugin-angular/src/lib/models/plugin-options.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/models/plugin-options.ts
@@ -18,6 +18,4 @@ export interface PluginAngularOptions {
   inlineStylesExtension: InlineStyleExtension;
   tsconfigPath: string;
   hasServer: boolean;
-  useParallelCompilation: boolean;
-  useHoistedJavascriptProcessing: boolean;
 }

--- a/packages/rsbuild-plugin-angular/src/lib/plugin/plugin-hoisted-js-transformer.ts
+++ b/packages/rsbuild-plugin-angular/src/lib/plugin/plugin-hoisted-js-transformer.ts
@@ -24,10 +24,7 @@ export const pluginHoistedJsTransformer = (
   setup(api) {
     const pluginOptions = normalizeOptions(options);
     const config = api.getRsbuildConfig();
-    const sourceFileCache = new SourceFileCache();
     const typescriptFileCache = new Map<string, string | Uint8Array>();
-    let nextProgram: NgtscProgram | undefined | ts.Program;
-    let builderProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram;
     let watchMode = false;
     let fileEmitter: FileEmitter;
     let isServer = pluginOptions.hasServer;
@@ -50,36 +47,16 @@ export const pluginHoistedJsTransformer = (
     });
 
     api.onBeforeEnvironmentCompile(async () => {
-      if (!pluginOptions.useParallelCompilation) {
-        const { rootNames, compilerOptions, host } = await setupCompilation(
-          config,
-          pluginOptions,
-          isServer,
-          true
-        );
-        // Only store cache if in watch mode
-        if (watchMode) {
-          augmentHostWithCaching(host, sourceFileCache);
-        }
-
-        fileEmitter = await buildAndAnalyze(
-          rootNames,
-          host,
-          compilerOptions,
-          nextProgram,
-          builderProgram,
-          { watchMode, jit: pluginOptions.jit }
-        );
-      } else {
-        const parallelCompilation =
-          await setupCompilationWithParallelCompilation(config, pluginOptions);
-        await buildAndAnalyzeWithParallelCompilation(
-          parallelCompilation,
-          typescriptFileCache,
-          javascriptTransformer
-        );
-        await parallelCompilation.close();
-      }
+      const parallelCompilation = await setupCompilationWithParallelCompilation(
+        config,
+        pluginOptions
+      );
+      await buildAndAnalyzeWithParallelCompilation(
+        parallelCompilation,
+        typescriptFileCache,
+        javascriptTransformer
+      );
+      await parallelCompilation.close();
     });
 
     api.transform({ test: JS_ALL_EXT_REGEX }, ({ code, resource }) => {


### PR DESCRIPTION
Parallel Compilation is the fastest and safest manner to build the angular applications.

Remove the `useParallelCompilation` to ensure it is the default
