### PR TITLE
test(compiler): fix setup compiler integration tests

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -99,7 +99,7 @@
       "options": {
         "testTargetName": "integration-test"
       },
-      "include": ["packages/rsbuild-plugin-angular/*"]
+      "include": ["packages/**"]
     },
     {
       "plugin": "@nx/playwright/plugin",

--- a/packages/compiler/mocks/fixtures/integration/minimal/rsbuild.mock.config.ts
+++ b/packages/compiler/mocks/fixtures/integration/minimal/rsbuild.mock.config.ts
@@ -1,7 +1,41 @@
-import { createConfig } from '../../../../src';
+import { defineConfig } from '@rsbuild/core';
 
-export default createConfig({
-  browser: './src/main.ts',
-  inlineStylesExtension: 'css',
-  tsconfigPath: './mocks/fixtures/integration/minimal/tsconfig.mock.json',
+export default defineConfig({
+  root: './',
+  source: {
+    tsconfigPath: './mocks/fixtures/integration/minimal/tsconfig.mock.json',
+  },
+  server: {
+    host: 'localhost',
+    port: 4200,
+    htmlFallback: false,
+    historyApiFallback: {
+      index: '/index.html',
+      rewrites: [{ from: /^\/$/, to: 'index.html' }],
+    },
+  },
+  tools: {
+    rspack(config) {
+      config.resolve ??= {};
+      config.resolve.extensionAlias = {};
+    },
+  },
+  environments: {
+    browser: {
+      source: {
+        entry: {
+          index: './src/main.ts',
+        },
+      },
+      output: {
+        target: 'web',
+        distPath: {
+          root: 'dist/browser',
+        },
+      },
+      html: {
+        template: 'index.html',
+      },
+    },
+  },
 });

--- a/packages/compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/compiler/src/compilation/setup-compilation.integration.test.ts
@@ -3,8 +3,7 @@ import { styleTransform } from './setup-compilation.ts';
 import { setupCompilation } from './setup-compilation.ts';
 import * as compilerCli from '@angular/compiler-cli';
 import path from 'node:path';
-// @TODO At the moment this tests rely on another function (createConfig)
-// The tests should be free of any dependencies.
+
 import rsBuildMockConfig from '../../mocks/fixtures/integration/minimal/rsbuild.mock.config.ts';
 
 describe('styleTransform', () => {

--- a/packages/compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/compiler/src/compilation/setup-compilation.integration.test.ts
@@ -6,14 +6,14 @@ import path from 'node:path';
 import rsBuildMockConfig from '../../mocks/fixtures/integration/minimal/rsbuild.mock.config.ts';
 
 vi.mock('../utils/load-compiler-cli', async (importOriginal) => {
-
-  const original = await importOriginal() as typeof import('@angular/compiler-cli');
+  const original =
+    (await importOriginal()) as typeof import('@angular/compiler-cli');
   return {
     ...original,
     loadCompilerCli: async () => {
-      return Promise.resolve();
-    }
-  }
+      return import('@angular/compiler-cli');
+    },
+  };
 });
 
 describe('styleTransform', () => {

--- a/packages/compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/compiler/src/compilation/setup-compilation.integration.test.ts
@@ -11,7 +11,7 @@ vi.mock('../utils/load-compiler-cli', async (importOriginal) => {
   return {
     ...original,
     loadCompilerCli: async () => {
-      return import('@angular/compiler-clix');
+      return Promise.resolve();
     }
   }
 });

--- a/packages/compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/compiler/src/compilation/setup-compilation.integration.test.ts
@@ -11,7 +11,7 @@ vi.mock('../utils/load-compiler-cli', async (importOriginal) => {
   return {
     ...original,
     loadCompilerCli: async () => {
-      return import('@angular/compiler-cli');
+      return import('@angular/compiler-clix');
     }
   }
 });

--- a/packages/compiler/src/compilation/setup-compilation.integration.test.ts
+++ b/packages/compiler/src/compilation/setup-compilation.integration.test.ts
@@ -1,10 +1,20 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { styleTransform } from './setup-compilation.ts';
 import { setupCompilation } from './setup-compilation.ts';
-import * as compilerCli from '@angular/compiler-cli';
 import path from 'node:path';
 
 import rsBuildMockConfig from '../../mocks/fixtures/integration/minimal/rsbuild.mock.config.ts';
+
+vi.mock('../utils/load-compiler-cli', async (importOriginal) => {
+
+  const original = await importOriginal() as typeof import('@angular/compiler-cli');
+  return {
+    ...original,
+    loadCompilerCli: async () => {
+      return import('@angular/compiler-cli');
+    }
+  }
+});
 
 describe('styleTransform', () => {
   it('should call scss.compileString and return the value of the css property', async () => {
@@ -37,43 +47,15 @@ describe('setupCompilation', () => {
     'minimal'
   );
 
-  // @TODO remove when test data are independent onbjects
-  it.skip('should read from correct tsconfigPath in rsBuildMockConfig', () => {
-    expect(rsBuildMockConfig.source?.tsconfigPath).toBe(
-      './mocks/fixtures/integration/minimal/tsconfig.mock.json'
-    );
-    expect(
-      compilerCli.readConfiguration(rsBuildMockConfig.source?.tsconfigPath, {})
-    ).toStrictEqual(
-      expect.objectContaining({
-        rootNames: [expect.stringMatching(/mock.main.ts$/)],
-      })
-    );
-  });
-
-  // @TODO remove when test data are independent onbjects
-  it.skip('should read from correct tsconfigPath in other tsconfig', () => {
-    expect(
-      compilerCli.readConfiguration(
-        path.join(fixturesDir, 'tsconfig.other.mock.json'),
-        {}
-      )
-    ).toStrictEqual(
-      expect.objectContaining({
-        rootNames: [expect.stringMatching(/mock.main.ts$/)],
-      })
-    );
-  });
-
-  it('should create compiler options form rsBuildConfig tsconfigPath', () => {
-    expect(
+  it('should create compiler options form rsBuildConfig tsconfigPath', async () => {
+    await expect(
       setupCompilation(rsBuildMockConfig, {
         tsconfigPath: 'irrelevant-if-tsconfig-is-in-rsbuild-config',
         jit: false,
         inlineStylesExtension: 'css',
         fileReplacements: [],
       })
-    ).toStrictEqual(
+    ).resolves.toStrictEqual(
       expect.objectContaining({
         compilerOptions: expect.objectContaining({
           configFilePath: expect.stringMatching(/tsconfig.mock.json$/),
@@ -83,8 +65,8 @@ describe('setupCompilation', () => {
     );
   });
 
-  it('should create compiler options form ts compiler options if rsBuildConfig tsconfigPath is undefined', () => {
-    expect(
+  it('should create compiler options form ts compiler options if rsBuildConfig tsconfigPath is undefined', async () => {
+    await expect(
       setupCompilation(
         {
           ...rsBuildMockConfig,
@@ -100,7 +82,7 @@ describe('setupCompilation', () => {
           fileReplacements: [],
         }
       )
-    ).toStrictEqual(
+    ).resolves.toStrictEqual(
       expect.objectContaining({
         compilerOptions: expect.objectContaining({}),
         rootNames: [expect.stringMatching(/other\/mock.main.ts$/)],


### PR DESCRIPTION
This PR includes:
- fixing broken integration test

> **Why where the tests broken?**
> I the past we forgot to enable integration tests for all packages. A later refactoring of the code broken the tests but we never run them in CI. 